### PR TITLE
chore(nix): point release-info at v0.7.8

### DIFF
--- a/nix/release-info.nix
+++ b/nix/release-info.nix
@@ -1,5 +1,5 @@
 {
-  version = "0.7.6";
+  version = "0.7.8";
 
   # SHA256 SRI hashes of each prebuilt artifact published in the matching
   # GitHub Release. This file is a per-branch channel pointer: on `main` it
@@ -21,12 +21,12 @@
   # Then update `version`, the two `url`s, and the two `hash`es below.
   artifacts = {
     "x86_64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.6/dbflux-linux-amd64.tar.gz";
-      hash = "sha256-D5apBzfzFa/jujKhvZ+kDkLrIaUZ3QbHmaYymHRyj3Y=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.8/dbflux-linux-amd64.tar.gz";
+      hash = "sha256-snDzO+FPm5/yWf1VQ8LolU2pnsREVaEEtd5+SNWUpT8=";
     };
     "aarch64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.6/dbflux-linux-arm64.tar.gz";
-      hash = "sha256-rm+LgsDHogA/bPnfeVhBcpjrI8HGWJw3l1V8EhLjl1I=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.8/dbflux-linux-arm64.tar.gz";
+      hash = "sha256-I7J8C/3BMbNWMuKer6h/amDeIUlXmqYNdMnsP6kky4U=";
     };
   };
 }


### PR DESCRIPTION
## Summary

Point the `main` Nix channel pointer at the published v0.7.8 artifacts (it was still at v0.7.6; the v0.7.7 bump was never applied).

## What does this resolve?

- Post-release step for v0.7.8 (see docs/RELEASE.md, Nix bump). Refs #513.

## How was this solved?

Updated `version`, both `url`s and both SRI hashes in `nix/release-info.nix`. Hashes derived from the `.sha256` files published with the release via `nix-hash --to-sri`.

## Validation

- `nix build .#dbflux-bin --no-link --print-out-paths` (see PR checks / local run).

## Where was this tested?

- [x] Local development environment
- [x] Linux

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I applied the appropriate labels